### PR TITLE
added repaint on selection change

### DIFF
--- a/Assets/NodeInspector/Scripts/Editor/NodeInspector.cs
+++ b/Assets/NodeInspector/Scripts/Editor/NodeInspector.cs
@@ -137,7 +137,12 @@ namespace NodeInspector.Editor{
                 return graphList.Values.ElementAt(currentGraphId);
             }
         }
-         
+
+        void OnSelectionChange()
+        {
+            Repaint();
+        }
+
         bool CheckSelectedObject(){
             if (Selection.activeObject == null || !(Selection.activeObject is ScriptableObject)){
                 return false;


### PR DESCRIPTION
Project view selection change triggers editor window repaint. Still does
not properly update the contents of the window (connections especially)
until you click inside it and it recalculates the size.
